### PR TITLE
Add CATEGORY_LABEL_ORDER to constants

### DIFF
--- a/components/project/chart/component.tsx
+++ b/components/project/chart/component.tsx
@@ -11,15 +11,15 @@ import { getProjectCategoriesPercentage } from 'utils/project';
 import { ProjectChartProps } from './types';
 
 // constants
-import { TITLE_MAX_LENGTH } from './constants';
+import { TITLE_MAX_LENGTH, CATEGORY_LABEL_ORDER } from './constants';
 
 export const ProjectChart: React.FC<ProjectChartProps> = (props: ProjectChartProps) => {
   const { project, highlightedCategory, cardMode } = props;
   const [categoryPercentages, setCategoryPercentages] = useState({
     [Category.Context]: 0,
-    [Category.Social]: 0,
-    [Category.Economic]: 0,
     [Category.Ecological]: 0,
+    [Category.Economic]: 0,
+    [Category.Social]: 0,
     [Category.Institutional]: 0,
   });
 
@@ -102,7 +102,7 @@ export const ProjectChart: React.FC<ProjectChartProps> = (props: ProjectChartPro
             appendTo={() => document.body}
             content={
               <div className="categories-tooltip">
-                {Object.keys(categoryPercentages).map(cKey => (
+                {CATEGORY_LABEL_ORDER.map(cKey => (
                   <div
                     key={cKey}
                     className="percentage-value"

--- a/components/project/chart/component.tsx
+++ b/components/project/chart/component.tsx
@@ -113,7 +113,7 @@ export const ProjectChart: React.FC<ProjectChartProps> = (props: ProjectChartPro
                       minWidth: '100%',
                     }}
                   >
-                    <label>{cKey}:</label>
+                    <label>{cKey === highlightedCategory ? <b>{cKey}</b> : cKey}:</label>
                     <span style={{ margin: '0 0 0.25rem 1rem' }}>
                       {Math.round(categoryPercentages[cKey])}
                     </span>

--- a/components/project/chart/component.tsx
+++ b/components/project/chart/component.tsx
@@ -11,7 +11,7 @@ import { getProjectCategoriesPercentage } from 'utils/project';
 import { ProjectChartProps } from './types';
 
 // constants
-import { TITLE_MAX_LENGTH, CATEGORY_LABEL_ORDER } from './constants';
+import { TITLE_MAX_LENGTH } from './constants';
 
 export const ProjectChart: React.FC<ProjectChartProps> = (props: ProjectChartProps) => {
   const { project, highlightedCategory, cardMode } = props;
@@ -102,7 +102,7 @@ export const ProjectChart: React.FC<ProjectChartProps> = (props: ProjectChartPro
             appendTo={() => document.body}
             content={
               <div className="categories-tooltip">
-                {CATEGORY_LABEL_ORDER.map(cKey => (
+                {Object.keys(categoryPercentages).map(cKey => (
                   <div
                     key={cKey}
                     className="percentage-value"

--- a/components/project/chart/constants.ts
+++ b/components/project/chart/constants.ts
@@ -1,2 +1,1 @@
 export const TITLE_MAX_LENGTH = 100;
-export const CATEGORY_LABEL_ORDER = ['Context', 'Ecological', 'Economic', 'Social', 'Institutional'];

--- a/components/project/chart/constants.ts
+++ b/components/project/chart/constants.ts
@@ -1,1 +1,2 @@
 export const TITLE_MAX_LENGTH = 100;
+export const CATEGORY_LABEL_ORDER = ['Context', 'Ecological', 'Economic', 'Social', 'Institutional'];

--- a/utils/project.js
+++ b/utils/project.js
@@ -9,8 +9,8 @@ import {
 
 export const getProjectCategoriesPercentage = project => ({
   [CONTEXT_CATEGORY]: getPercentageForCategory(project, CONTEXT_CATEGORY),
-  [ECONOMIC_CATEGORY]: getPercentageForCategory(project, ECONOMIC_CATEGORY),
   [ECOLOGICAL_CATEGORY]: getPercentageForCategory(project, ECOLOGICAL_CATEGORY),
+  [ECONOMIC_CATEGORY]: getPercentageForCategory(project, ECONOMIC_CATEGORY),
   [INSTITUTIONAL_CATEGORY]: getPercentageForCategory(project, INSTITUTIONAL_CATEGORY),
   [SOCIAL_CATEGORY]: getPercentageForCategory(project, SOCIAL_CATEGORY),
 });


### PR DESCRIPTION
Resolves https://github.com/mongabay/reforestation-catalogue/issues/16#issue-871043389 and adds a sort order for the categories to `constants`.

Tooltip categories now match the chart with the order being: `'Context', 'Ecological', 'Economic', 'Social', 'Institutional'`

<img width="445" alt="Screen Shot 2021-04-29 at 17 18 27" src="https://user-images.githubusercontent.com/30242314/116579061-4e1d9880-a912-11eb-905b-3f2c46a64788.png">

BONUS: Bolds the highlighted category in the tooltip