### PR TITLE
MP-89 Fixes column types in projects table

### DIFF
--- a/backend/db/migrate/20220621113730_fix_project_columns.rb
+++ b/backend/db/migrate/20220621113730_fix_project_columns.rb
@@ -1,0 +1,48 @@
+class FixProjectColumns < ActiveRecord::Migration[7.0]
+  def up
+    integer_columns.each do |col_name|
+      col_props = Project.columns.find { |c| c.name == col_name }
+      rename_column :projects, col_name, "#{col_name}_tmp"
+      add_column :projects, col_name, :integer
+      if col_props.sql_type == 'integer'
+        execute "UPDATE projects SET #{col_name} = #{col_name}_tmp"
+      else
+        execute "UPDATE projects SET #{col_name} = #{col_name}_tmp::INT"
+      end
+    end
+
+    integer_array_columns.each do |col_name|
+      col_props = Project.columns.find { |c| c.name == col_name }
+      rename_column :projects, col_name, "#{col_name}_tmp"
+      add_column :projects, col_name, :integer, default: [], array: true
+      if col_props.sql_type == 'integer'
+        execute "UPDATE projects SET #{col_name} = #{col_name}_tmp"
+      else
+        execute "UPDATE projects SET #{col_name} = STRING_TO_ARRAY(REGEXP_REPLACE(#{col_name}_tmp, '\\[(.*)\\]', '\\1'), ',')::INT[]"
+      end
+    end
+  end
+
+  def down
+    # this is in case we need to roll back
+    (integer_columns + integer_array_columns).each do |col_name|
+      remove_column :projects, col_name
+      rename_column :projects, "#{col_name}_tmp", col_name
+    end
+  end
+end
+
+def integer_columns
+  ['organization_type']
+end
+
+def integer_array_columns
+  [
+    'who_is_involved',
+    'forest_type',
+    'primary_objective_purpose',
+    'approach',
+    'financial_model',
+    'type_of_follow_up'
+  ]
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_09_120757) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_21_113730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,8 +74,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_09_120757) do
     t.integer "project_number"
     t.string "project_name"
     t.string "lead_organization"
-    t.integer "organization_type"
-    t.integer "who_is_involved", default: [], array: true
+    t.string "organization_type_tmp"
+    t.string "who_is_involved_tmp"
     t.string "project_org_url"
     t.boolean "has_project_partners"
     t.string "partner_name"
@@ -86,9 +86,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_09_120757) do
     t.float "size_of_project_ha"
     t.integer "trees_planted_number"
     t.boolean "has_explicit_location"
-    t.integer "forest_type", default: [], array: true
-    t.integer "primary_objective_purpose", default: [], array: true
-    t.integer "approach", default: [], array: true
+    t.string "forest_type_tmp"
+    t.string "primary_objective_purpose_tmp"
+    t.string "approach_tmp"
     t.boolean "identify_deforestation_driver"
     t.boolean "fire_prevention"
     t.boolean "has_justification_for_approach"
@@ -97,11 +97,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_09_120757) do
     t.boolean "use_native_species"
     t.boolean "use_exotic_species"
     t.boolean "local_seedling_nurseries"
-    t.integer "financial_model", default: [], array: true
+    t.string "financial_model_tmp"
     t.string "name_org_donor"
     t.boolean "has_public_reports"
     t.boolean "follow_up_disclosed"
-    t.integer "type_of_follow_up", default: [], array: true
+    t.string "type_of_follow_up_tmp"
     t.boolean "has_community_involvement"
     t.boolean "has_gender_component"
     t.boolean "scientific_research_associated_with_project"
@@ -112,6 +112,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_09_120757) do
     t.boolean "highlighted", default: false
     t.boolean "approved", default: false
     t.bigint "project_id"
+    t.integer "organization_type"
+    t.integer "who_is_involved", default: [], array: true
+    t.integer "forest_type", default: [], array: true
+    t.integer "primary_objective_purpose", default: [], array: true
+    t.integer "approach", default: [], array: true
+    t.integer "financial_model", default: [], array: true
+    t.integer "type_of_follow_up", default: [], array: true
     t.index ["project_id"], name: "index_projects_on_project_id"
   end
 


### PR DESCRIPTION
This fixes column data type in projects table, so that they're represented as integers or integer arrays. 

The way it is done has 3 objectives in mind - to be able to apply this in staging and production without messeing up, to be able to rollback easily, and to not further mess up schema.rb. For every affected column it:
- adds a _tmp suffix to old column name
- adds a new column with target name and correct type (integer or integer[])
- if the old column was already correct type, copies the value to the new column as is
- if the old column was a string, copies the value to the new column cast to integer or integer[]

To roll this back, we drop the new column and remove the _tmp suffix from the old column, whose content is unchanged

To clean the mess up when this is tested to be correct, in a later migration we will just drop all _tmp columns and all is good again, except for 

https://vizzuality.atlassian.net/browse/MP-89
