### PR TITLE
MP-118 Added "who is involved" to backoffice project form

### DIFF
--- a/backend/app/admin/projects_admin.rb
+++ b/backend/app/admin/projects_admin.rb
@@ -105,8 +105,9 @@ Trestle.resource(:projects) do
       resource_type_of_follow_ups = Project.type_of_follow_ups.keys.map { |type_of_follow_up| [type_of_follow_up.humanize, type_of_follow_up] }
       select :type_of_follow_up, resource_type_of_follow_ups, { label: "Type of follow up" }, multiple: true
 
+      resource_who_is_involved = Project.who_is_involveds.keys.map { |who_is_involved| [who_is_involved.humanize, who_is_involved] }
+      select :who_is_involved, resource_who_is_involved, { label: 'Who is involved'}, multiple: true
 
-      
       check_box :highlighted
       check_box :approved
     end


### PR DESCRIPTION
Adds multi-select for "who is involved" to the project form

<img width="763" alt="Screenshot 2022-11-10 at 09 52 23" src="https://user-images.githubusercontent.com/134055/201044690-f5ea8c61-5c32-41fd-9d93-ec5ea94dd542.png">


## Tracking

https://vizzuality.atlassian.net/browse/MP-118?atlOrigin=eyJpIjoiZTE0ZjM5ZWQ5NGNiNDNkYzhkYWRiZTViNGRjZDZiMWYiLCJwIjoiaiJ9
