### PR TITLE
MP-154 Changes to project links

### DIFF
--- a/backend/app/admin/project_links_admin.rb
+++ b/backend/app/admin/project_links_admin.rb
@@ -12,7 +12,15 @@ Trestle.resource(:project_links) do
   #
   table do
     column :project_name
-    column :title
+    column :title do |project_link|
+      if project_link.updated_from_previous_version?
+        changed_badge + project_link.title
+      elsif project_link.previous_version.nil? && !project_link.approved?
+        added_badge + project_link.title
+      else
+        project_link.title
+      end
+    end
     column :description
     column :url
     # column :created_at, align: :center
@@ -27,9 +35,9 @@ Trestle.resource(:project_links) do
     else
       select :project_id, Project.all.map { |p| [p.project_name, p.id] }
     end
-    text_field :title
-    text_field :description
-    text_field :url
+    text_field_with_diff :title
+    text_field_with_diff :description
+    text_field_with_diff :url
 
     if project_link.project
       concat admin_link_to('Back to project', admin: :projects, action: :edit, params: { id: project_link.project }, class: 'btn btn-success')

--- a/backend/app/admin/projects_admin.rb
+++ b/backend/app/admin/projects_admin.rb
@@ -31,9 +31,9 @@ Trestle.resource(:projects) do
 
   scopes do
     scope :all, default: true
-    scope :approved, -> { Project.unscoped.where(approved: true) }
-    scope :pending, -> { Project.unscoped.where(approved: false) }
-    scope :highlighted, -> { Project.unscoped.where(highlighted: true) }
+    scope :approved, -> { Project.unscoped.where(approved: true).order(:project_name) }
+    scope :pending, -> { Project.unscoped.where(approved: false).order(:project_name) }
+    scope :highlighted, -> { Project.unscoped.where(highlighted: true).order(:project_name) }
   end
 
   # Customize the table columns shown on the index view.
@@ -41,7 +41,9 @@ Trestle.resource(:projects) do
   table do
     column :project_name do |project|
       if project.updated_from_previous_version?
-        update_badge + project.project_name
+        changed_badge + project.project_name
+      elsif project_link.previous_version.nil? && !project.approved?
+        added_badge + project.project_name
       else
         project.project_name
       end
@@ -118,11 +120,32 @@ Trestle.resource(:projects) do
     end
 
     tab :project_links do
+      concat content_tag(:h4, 'Added or changed links', class: 'mt-3 mb-0')
+
       table project.project_links, admin: :project_links do
-        column :title
+        column :title do |project_link|
+          if project_link.updated_from_previous_version?
+            changed_badge + project_link.title
+          elsif project_link.previous_version.nil? && !project_link.approved?
+            added_badge + project_link.title
+          else
+            project_link.title
+          end
+        end
         column :description
         column :url
       end
+
+      concat content_tag(:h4, 'Removed links', class: 'mt-3 mb-0')
+
+      table project.removed_project_links do
+        column :title do |project_link|
+          removed_badge + content_tag(:div, project_link.title)
+        end
+        column :description
+        column :url
+      end
+
 
       concat admin_link_to('New Link', admin: :project_links, action: :new, params: { project_id: project }, class: 'btn btn-success')
     end

--- a/backend/app/helpers/trestle_helper.rb
+++ b/backend/app/helpers/trestle_helper.rb
@@ -1,11 +1,24 @@
 module TrestleHelper
-  def update_badge
-    content_tag(:span, "UPDATE", class: "badge badge-warning mr-1")
+  def changed_badge
+    content_tag(:span, "CHANGED", class: "badge badge-warning mr-1")
   end
 
-  def update_info(info)
+  def added_badge
+    content_tag(:span, "ADDED", class: "badge badge-info mr-1")
+  end
+
+  def removed_badge
+    content_tag(:span, "REMOVED", class: "badge badge-danger mr-1")
+  end
+
+  def changed_info(info)
+    formatted_info = info
+    formatted_info = '(empty)' unless info.present?
+    formatted_info = 'Yes' if info == true
+    formatted_info = 'No' if info == false
+
     content_tag(:div, class: "diff my-1 p-1", style: "background-color: #eee") do
-      update_badge + content_tag(:span, info, class: "pl-1")
+      changed_badge + content_tag(:span, formatted_info, class: "pl-1")
     end
   end
 end

--- a/backend/app/models/project_link.rb
+++ b/backend/app/models/project_link.rb
@@ -1,5 +1,13 @@
 class ProjectLink < ApplicationRecord
   belongs_to :project
+  belongs_to :previous_version, optional: true, class_name: 'ProjectLink'
 
   delegate :project_name, to: :project, allow_nil: true
+  delegate :approved?, to: :project, allow_nil: true
+
+  def updated_from_previous_version?
+    previous_version.present? && (
+      title != previous_version.title || description != previous_version.description
+    )
+  end
 end

--- a/backend/config/initializers/trestle.rb
+++ b/backend/config/initializers/trestle.rb
@@ -271,7 +271,7 @@ Trestle.configure do |config|
       return nil unless diff
 
       previous_value = previous_value.map(&:humanize).join(", ") if previous_value.is_a? Array
-      update_info(previous_value)
+      changed_info(previous_value)
     end
   end
 

--- a/backend/db/migrate/20220622115109_add_previous_version_id_to_projects.rb
+++ b/backend/db/migrate/20220622115109_add_previous_version_id_to_projects.rb
@@ -1,5 +1,5 @@
 class AddPreviousVersionIdToProjects < ActiveRecord::Migration[7.0]
   def change
-    add_reference :projects, :previous_version, foreign_key: { to_table: :projects }, null: true
+    add_reference :projects, :previous_version, foreign_key: {to_table: :projects}, null: true
   end
 end

--- a/backend/db/migrate/20230116085623_add_previous_version_id_to_project_links.rb
+++ b/backend/db/migrate/20230116085623_add_previous_version_id_to_project_links.rb
@@ -1,0 +1,6 @@
+class AddPreviousVersionIdToProjectLinks < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :project_links, :previous_version, foreign_key: {to_table: :project_links}, null: true
+    Project.where(approved: false).each(&:fixup_project_links_previous_version)
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_22_115109) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_16_085623) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,6 +67,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_22_115109) do
     t.string "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "previous_version_id"
+    t.index ["previous_version_id"], name: "index_project_links_on_previous_version_id"
     t.index ["project_id"], name: "index_project_links_on_project_id"
   end
 
@@ -142,5 +144,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_22_115109) do
   end
 
   add_foreign_key "filters", "categories"
+  add_foreign_key "project_links", "project_links", column: "previous_version_id"
   add_foreign_key "projects", "projects", column: "previous_version_id"
 end

--- a/backend/spec/requests/api/v1/project_update_spec.rb
+++ b/backend/spec/requests/api/v1/project_update_spec.rb
@@ -4,10 +4,18 @@ RSpec.describe 'Api::V1::Projects', type: :request do
   describe 'Update project' do
     before(:each) do
       @project = FactoryBot.create(:project, approved: true, start_year: 2020, end_year: 2022)
+      @project_link = FactoryBot.create(:project_link, project: @project)
     end
 
     let(:headers) { { 'ACCEPT' => 'application/json' } }
-    let(:update_params) { {project: {'start_year' => 2021}} }
+    let(:update_params) {
+      {
+        project: {
+          'start_year' => 2021,
+          project_links_attributes: [{url: @project_link.url, title: 'test', description: 'test'}]
+        }
+      }
+    }
 
     context "when updating approved project" do
       it 'does not update approved project' do
@@ -18,6 +26,12 @@ RSpec.describe 'Api::V1::Projects', type: :request do
       it 'creates a new version of approved project' do
         put "/api/v1/projects/#{@project.id}", params: update_params
         new_version = Project.find_by_previous_version_id(@project.id)
+        expect(new_version).not_to be_nil
+      end
+
+      it 'creates a new version of project link' do
+        put "/api/v1/projects/#{@project.id}", params: update_params
+        new_version = ProjectLink.find_by_previous_version_id(@project_link.id)
         expect(new_version).not_to be_nil
       end
 


### PR DESCRIPTION
This builds on https://github.com/mongabay/reforestation-catalogue/pull/70 to add version control information to project links.

<img width="1157" alt="Screenshot 2023-01-16 at 13 52 54" src="https://user-images.githubusercontent.com/134055/212682987-1619e5f5-d3c7-460d-a8ed-8d203a41c212.png">


Added / changed links are separated from removed links. There are no actions available on removed links, whereas added / changed can be updated / deleted using the existing functionality of backoffice lists.


## Testing instructions

Use the "suggest page edits function" to suggest changes to a project's links. Try adding, removing, updating.

Next, in the admin tool check the "project links" sub-tab on a pending project to see if all changes were labelled correctly.

Please note: if a user updates an existing link by changing its url, the system detects that as removing an old link and adding a new one. That is because we would need changes on the frontend to associate these 2 records (currently association works b checking the url)

## JIRA

https://vizzuality.atlassian.net/browse/MP-154
